### PR TITLE
Publish Tasks can use Access Tokens for auth

### DIFF
--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -76,14 +76,13 @@ export async function run(): Promise<void> {
         const isInternalFeed: boolean = nugetFeedType === 'internal';
         let endpoint = tl.getInput('externalEndpoint', false);
         if(endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will try use token for auth");
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
             {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    tl.debug('let token:' + accessToken)
                     break;
                 default:
                     tl.warning("Invalid authentication type for internal feed. Use token based authentication.");

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -11,6 +11,12 @@ import * as ngRunner from 'azure-pipelines-tasks-packaging-common/nuget/NuGetToo
 import * as pkgLocationUtils from 'azure-pipelines-tasks-packaging-common/locationUtilities';
 import { getProjectAndFeedIdFromInputParam, logError } from 'azure-pipelines-tasks-packaging-common/util';
 
+interface EndpointCredentials {
+    endpoint: string;
+    username?: string;
+    password: string;
+}
+
 export async function run(): Promise<void> {
     let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
@@ -65,14 +71,51 @@ export async function run(): Promise<void> {
         }
 
         // Setting up auth info
-        let accessToken: string;
-        const isInternalFeed: boolean = nugetFeedType === "internal";
-        if (isInternalFeed){
-            accessToken = getAccessToken('externalEndpoint', 'feedPublish');
+        let accessToken;
+        let feed;
+        const isInternalFeed: boolean = nugetFeedType === 'internal';
+        let endpoint = tl.getInput('externalEndpoint', false);
+        if(endpoint && isInternalFeed === true) {
+            tl.debug("Found external endpoint, will try use token for auth");
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch(endpointScheme)
+            {
+                case ("token"):
+                    accessToken = endpointAuth.parameters["apitoken"];
+                    tl.debug('let token:' + accessToken)
+                    break;
+                default:
+                    tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                    break;
+            }
         }
-        else{
+        if(!accessToken && isInternalFeed === true)
+        {            
+            tl.debug("Checking for auth from Cred Provider."); 
+            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+            const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
+            if (JsonEndpointsString) {
+                tl.debug(`Endpoints found: ${JsonEndpointsString}`);
+
+                let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
+                tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
+
+                for (let endpoint_in = 0; endpoint_in < endpointsArray.endpointCredentials.length; endpoint_in++) {
+                    if (endpointsArray.endpointCredentials[endpoint_in].endpoint.search(feed.feedName) != -1) {
+                        tl.debug(`Endpoint Credentials found for ${feed.feedName}`);
+                        accessToken = endpointsArray.endpointCredentials[endpoint_in].password;
+                        break;
+                    }
+                }
+            }
+        }
+        if(!accessToken)
+        {
+            tl.debug('Defaulting to use the System Access Token.');
             accessToken = pkgLocationUtils.getSystemAccessToken();
         }
+        const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
 
         let configFile = null;
         let apiKey: string;
@@ -90,12 +133,7 @@ export async function run(): Promise<void> {
         let authInfo: auth.NuGetExtendedAuthInfo;
         let nuGetConfigHelper: NuGetConfigHelper2;
 
-        let feed = getProjectAndFeedIdFromInputParam('feedPublish');
-
-        // If a feed is specified, we are publishing to an internal feed. Try either service connection or env variables 
-        if(feed){
-            const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
-
+        if (isInternalFeed) {
             authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
             nuGetConfigHelper = new NuGetConfigHelper2(
                 null,
@@ -105,6 +143,8 @@ export async function run(): Promise<void> {
                 tempNuGetPath,
                 false /* useNugetToModifyConfigFile */);
 
+            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+
             feedUri = await nutil.getNuGetFeedRegistryUrl(packagingLocation.DefaultPackagingUri, feed.feedId, feed.projectId, null, accessToken, /* useSession */ true);
             nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
             configFile = nuGetConfigHelper.tempNugetConfigPath;
@@ -112,9 +152,6 @@ export async function run(): Promise<void> {
 
             apiKey = 'VSTS';
         } else {
-            accessToken = pkgLocationUtils.getSystemAccessToken();
-            const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
-
             const externalAuthArr = commandHelper.GetExternalAuthInfoArray('externalEndpoint');
             authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
             nuGetConfigHelper = new NuGetConfigHelper2(

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 221,
+        "Minor": 236,
         "Patch": 0
     },
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 221,
+    "Minor": 236,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/NpmV1/npmpublish.ts
+++ b/Tasks/NpmV1/npmpublish.ts
@@ -5,7 +5,9 @@ import { INpmRegistry, NpmRegistry } from 'azure-pipelines-tasks-packaging-commo
 import { NpmToolRunner } from './npmtoolrunner';
 import * as util from 'azure-pipelines-tasks-packaging-common/util';
 import * as npmutil from 'azure-pipelines-tasks-packaging-common/npm/npmutil';
-import { PackagingLocation } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as npmrcparser from 'azure-pipelines-tasks-packaging-common/npm/npmrcparser';
+import { PackagingLocation, getFeedRegistryUrl, RegistryType } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as os from 'os';
 
 export async function run(packagingLocation: PackagingLocation): Promise<void> {
     const workingDir = tl.getInput(NpmTaskInput.WorkingDir) || process.cwd();
@@ -33,7 +35,8 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
         case RegistryLocation.Feed:
             tl.debug(tl.loc('PublishFeed'));
             const feed = util.getProjectAndFeedIdFromInputParam(NpmTaskInput.PublishFeed);
-            npmRegistry = await NpmRegistry.FromFeedId(
+            npmRegistry = util.isUserAccessTokenRequired(feed.feedId) ? await getNpmRegistry(packagingLocation.DefaultPackagingUri, feed, false, true) : await NpmRegistry.FromFeedId
+            (
                 packagingLocation.DefaultPackagingUri,
                 feed.feedId,
                 feed.projectId,
@@ -47,4 +50,45 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
             break;
     }
     return npmRegistry;
+}
+
+async function getNpmRegistry(defaultPackagingUri: string, feed: any, authOnly?: boolean, useSession?: boolean) {
+    const lineEnd = os.EOL;
+    let url: string;
+    let nerfed: string;
+    let auth: string;
+    let username: string;
+    let email: string;
+    let password64: string;
+    let accessToken: string;
+
+    url = npmrcparser.NormalizeRegistry( await getFeedRegistryUrl(defaultPackagingUri, RegistryType.npm, feed.feedId, feed.project, null, useSession));
+    nerfed = util.toNerfDart(url);
+    
+    let endpointName: string = tl.getInput('publishEndpoint');
+
+    if(endpointName){
+        tl.debug('Checking if the endpoint ${endpointName} provided by user, can be used.');
+        accessToken = getAccessTokenFromServiceConnectionForInternalFeeds(endpointName);
+    } else {
+        tl.debug('Checking if the credentials are set in the environment.');
+        accessToken = getAccessTokenFromEnvironmentForInternalFeeds(feed, util.PackageToolType.Npm);
+    }
+
+    if(!accessToken){
+        tl.warning('Access token not set. Using System Access token.');
+        accessToken = pkgLocationUtils.getSystemAccessToken();
+    }
+
+    // Azure DevOps does not support PATs+Bearer only JWTs+Bearer
+    email = 'VssEmail';
+    username = 'VssToken';
+    password64 = Buffer.from(apitoken).toString('base64');
+    tl.setSecret(password64);
+
+    auth = nerfed + ':username=' + username + lineEnd;
+    auth += nerfed + ':_password=' + password64 + lineEnd;
+    auth += nerfed + ':email=' + email + lineEnd;
+
+    return new NpmRegistry(url, auth, authOnly);
 }

--- a/Tasks/NpmV1/npmpublish.ts
+++ b/Tasks/NpmV1/npmpublish.ts
@@ -35,13 +35,7 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
         case RegistryLocation.Feed:
             tl.debug(tl.loc('PublishFeed'));
             const feed = util.getProjectAndFeedIdFromInputParam(NpmTaskInput.PublishFeed);
-            npmRegistry = util.isUserAccessTokenRequired(feed.feedId) ? await getNpmRegistry(packagingLocation.DefaultPackagingUri, feed, false, true) : await NpmRegistry.FromFeedId
-            (
-                packagingLocation.DefaultPackagingUri,
-                feed.feedId,
-                feed.projectId,
-                false /* authOnly */,
-                true /* useSession */);
+            npmRegistry = await getNpmRegistry(packagingLocation.DefaultPackagingUri, feed, false, true);
             break;
         case RegistryLocation.External:
             tl.debug(tl.loc('PublishExternal'));
@@ -64,22 +58,8 @@ async function getNpmRegistry(defaultPackagingUri: string, feed: any, authOnly?:
 
     url = npmrcparser.NormalizeRegistry( await getFeedRegistryUrl(defaultPackagingUri, RegistryType.npm, feed.feedId, feed.project, null, useSession));
     nerfed = util.toNerfDart(url);
-    
-    let endpointName: string = tl.getInput('publishEndpoint');
 
-    if(endpointName){
-        tl.debug('Checking if the endpoint ${endpointName} provided by user, can be used.');
-        accessToken = getAccessTokenFromServiceConnectionForInternalFeeds(endpointName);
-    } else {
-        tl.debug('Checking if the credentials are set in the environment.');
-        accessToken = getAccessTokenFromEnvironmentForInternalFeeds(feed, util.PackageToolType.Npm);
-    }
-
-    if(!accessToken){
-        tl.warning('Access token not set. Using System Access token.');
-        accessToken = pkgLocationUtils.getSystemAccessToken();
-    }
-
+    const apitoken = util.getAccessToken('publishEndpoint', 'publishFeed');
     // Azure DevOps does not support PATs+Bearer only JWTs+Bearer
     email = 'VssEmail';
     username = 'VssToken';

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 231,
+        "Minor": 236,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 231,
+    "Minor": 236,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/nugetpublisher.ts
+++ b/Tasks/NuGetCommandV2/nugetpublisher.ts
@@ -115,14 +115,13 @@ export async function run(nuGetPath: string): Promise<void> {
         let endpoint = tl.getInput('externalEndpoint', false);
 
         if(endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will try use token for auth");
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
             {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    tl.debug('let token:' + accessToken)
                     break;
                 default:
                     tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
@@ -130,7 +129,8 @@ export async function run(nuGetPath: string): Promise<void> {
             }
         }
         if(!accessToken && isInternalFeed === true)
-        {            
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
             const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
             if (JsonEndpointsString) {

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 231,
+        "Minor": 236,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 231,
+    "Minor": 236,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 231,
+    "Minor": 236,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 231,
+    "Minor": 236,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/universalpublish.ts
+++ b/Tasks/UniversalPackagesV0/universalpublish.ts
@@ -258,7 +258,32 @@ function authSetup(
         feedId = feedProject.feedId;
         projectId = feedProject.projectId;
 
-        accessToken = getAccessToken('externalEndpoint', 'feedListPublish'); 
+        // Setting up auth info
+        let endpoint = tl.getInput('externalEndpoints', false);
+        if(endpoint) {
+            tl.debug("Found external endpoint, will use token for auth");
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch(endpointScheme)
+            {
+                case ("token"):
+                    accessToken = endpointAuth.parameters["apitoken"];
+                    break;
+                default:
+                    tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                    break;
+            }
+        }
+        if(!accessToken)
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
+            accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
+        }
+        if(!accessToken)
+        {
+            tl.debug('Defaulting to use the System Access Token.');
+            accessToken = pkgLocationUtils.getSystemAccessToken();
+        }
     }
 
     else {

--- a/Tasks/UniversalPackagesV0/universalpublish.ts
+++ b/Tasks/UniversalPackagesV0/universalpublish.ts
@@ -261,7 +261,7 @@ function authSetup(
         // Setting up auth info
         let endpoint = tl.getInput('externalEndpoints', false);
         if(endpoint) {
-            tl.debug("Found external endpoint, will use token for auth");
+            tl.debug("Found external endpoint, will try to use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
@@ -276,7 +276,7 @@ function authSetup(
         }
         if(!accessToken)
         {           
-            tl.debug("Checking for auth from Cred Provider."); 
+            tl.debug("Checking for auth in environment variables."); 
             accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
         }
         if(!accessToken)

--- a/Tasks/UniversalPackagesV0/universalpublish.ts
+++ b/Tasks/UniversalPackagesV0/universalpublish.ts
@@ -5,7 +5,7 @@ import { ProvenanceHelper } from "azure-pipelines-tasks-packaging-common/provena
 import * as artifactToolRunner from "azure-pipelines-tasks-packaging-common/universal/ArtifactToolRunner";
 import * as artifactToolUtilities from "azure-pipelines-tasks-packaging-common/universal/ArtifactToolUtilities";
 import * as auth from "azure-pipelines-tasks-packaging-common/universal/Authentication";
-import { getProjectAndFeedIdFromInputParam, logError, getAccessTokenFromEnvironmentForInternalFeeds, getAccessTokenFromServiceConnectionForInternalFeeds } from 'azure-pipelines-tasks-packaging-common/util';
+import { getProjectAndFeedIdFromInputParam, logError } from 'azure-pipelines-tasks-packaging-common/util';
 import * as telemetry from "azure-pipelines-tasks-utility-common/telemetry";
 
 const packageAlreadyExistsError = 17;
@@ -258,23 +258,8 @@ function authSetup(
         feedId = feedProject.feedId;
         projectId = feedProject.projectId;
 
-        let feed = getProjectAndFeedIdFromInputParam('feedListPublish');
-        let endpointName: string = tl.getInput('externalEndpoint');
-
-        // Setting up auth info
-        if(endpointName){
-            tl.debug('Checking if the endpoint ${endpointName} provided by user, can be used.');
-            accessToken = getAccessTokenFromServiceConnectionForInternalFeeds(endpointName);
-        } else {
-        // If endpoint is not set up 
-            tl.debug('Checking if the credentials are set in the environment.');
-            accessToken = getAccessTokenFromEnvironmentForInternalFeeds(feed, PackageToolType.UniversalPackages);
-        }
-
-        if(!accessToken){
-            tl.warning('Access token not set. Using System Access token.');
-            accessToken = pkgLocationUtils.getSystemAccessToken();
-        }    }
+        accessToken = getAccessToken('externalEndpoint', 'feedListPublish'); 
+    }
 
     else {
         const externalAuthInfo = auth.GetExternalAuthInfo("externalEndpoints");

--- a/_generated/DotNetCoreCLIV2_Node20/pushcommand.ts
+++ b/_generated/DotNetCoreCLIV2_Node20/pushcommand.ts
@@ -76,14 +76,13 @@ export async function run(): Promise<void> {
         const isInternalFeed: boolean = nugetFeedType === 'internal';
         let endpoint = tl.getInput('externalEndpoint', false);
         if(endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will try use token for auth");
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
             {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    tl.debug('let token:' + accessToken)
                     break;
                 default:
                     tl.warning("Invalid authentication type for internal feed. Use token based authentication.");

--- a/_generated/DotNetCoreCLIV2_Node20/pushcommand.ts
+++ b/_generated/DotNetCoreCLIV2_Node20/pushcommand.ts
@@ -11,6 +11,12 @@ import * as ngRunner from 'azure-pipelines-tasks-packaging-common/nuget/NuGetToo
 import * as pkgLocationUtils from 'azure-pipelines-tasks-packaging-common/locationUtilities';
 import { getProjectAndFeedIdFromInputParam, logError } from 'azure-pipelines-tasks-packaging-common/util';
 
+interface EndpointCredentials {
+    endpoint: string;
+    username?: string;
+    password: string;
+}
+
 export async function run(): Promise<void> {
     let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
@@ -65,8 +71,50 @@ export async function run(): Promise<void> {
         }
 
         // Setting up auth info
-        const accessToken = pkgLocationUtils.getSystemAccessToken();
+        let accessToken;
+        let feed;
         const isInternalFeed: boolean = nugetFeedType === 'internal';
+        let endpoint = tl.getInput('externalEndpoint', false);
+        if(endpoint && isInternalFeed === true) {
+            tl.debug("Found external endpoint, will try use token for auth");
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch(endpointScheme)
+            {
+                case ("token"):
+                    accessToken = endpointAuth.parameters["apitoken"];
+                    tl.debug('let token:' + accessToken)
+                    break;
+                default:
+                    tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                    break;
+            }
+        }
+        if(!accessToken && isInternalFeed === true)
+        {            
+            tl.debug("Checking for auth from Cred Provider."); 
+            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+            const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
+            if (JsonEndpointsString) {
+                tl.debug(`Endpoints found: ${JsonEndpointsString}`);
+
+                let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
+                tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
+
+                for (let endpoint_in = 0; endpoint_in < endpointsArray.endpointCredentials.length; endpoint_in++) {
+                    if (endpointsArray.endpointCredentials[endpoint_in].endpoint.search(feed.feedName) != -1) {
+                        tl.debug(`Endpoint Credentials found for ${feed.feedName}`);
+                        accessToken = endpointsArray.endpointCredentials[endpoint_in].password;
+                        break;
+                    }
+                }
+            }
+        }
+        if(!accessToken)
+        {
+            tl.debug('Defaulting to use the System Access Token.');
+            accessToken = pkgLocationUtils.getSystemAccessToken();
+        }
         const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
 
         let configFile = null;

--- a/_generated/DotNetCoreCLIV2_Node20/task.json
+++ b/_generated/DotNetCoreCLIV2_Node20/task.json
@@ -522,7 +522,7 @@
       "target": "dotnetcore.js",
       "argumentFormat": ""
     },
-    "Node20": {
+    "Node20_1": {
       "target": "dotnetcore.js",
       "argumentFormat": ""
     }

--- a/_generated/DotNetCoreCLIV2_Node20/task.loc.json
+++ b/_generated/DotNetCoreCLIV2_Node20/task.loc.json
@@ -522,7 +522,7 @@
       "target": "dotnetcore.js",
       "argumentFormat": ""
     },
-    "Node20": {
+    "Node20_1": {
       "target": "dotnetcore.js",
       "argumentFormat": ""
     }

--- a/_generated/NpmV1/npmpublish.ts
+++ b/_generated/NpmV1/npmpublish.ts
@@ -5,7 +5,9 @@ import { INpmRegistry, NpmRegistry } from 'azure-pipelines-tasks-packaging-commo
 import { NpmToolRunner } from './npmtoolrunner';
 import * as util from 'azure-pipelines-tasks-packaging-common/util';
 import * as npmutil from 'azure-pipelines-tasks-packaging-common/npm/npmutil';
-import { PackagingLocation } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as npmrcparser from 'azure-pipelines-tasks-packaging-common/npm/npmrcparser';
+import { getSystemAccessToken, PackagingLocation, getFeedRegistryUrl, RegistryType } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as os from 'os';
 
 export async function run(packagingLocation: PackagingLocation): Promise<void> {
     const workingDir = tl.getInput(NpmTaskInput.WorkingDir) || process.cwd();
@@ -33,10 +35,9 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
         case RegistryLocation.Feed:
             tl.debug(tl.loc('PublishFeed'));
             const feed = util.getProjectAndFeedIdFromInputParam(NpmTaskInput.PublishFeed);
-            npmRegistry = await NpmRegistry.FromFeedId(
+            npmRegistry = await getNpmRegistry(
                 packagingLocation.DefaultPackagingUri,
-                feed.feedId,
-                feed.projectId,
+                feed, 
                 false /* authOnly */,
                 true /* useSession */);
             break;
@@ -47,4 +48,58 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
             break;
     }
     return npmRegistry;
+}
+
+async function getNpmRegistry(defaultPackagingUri: string, feed: any, authOnly?: boolean, useSession?: boolean) {
+    const lineEnd = os.EOL;
+    let url: string;
+    let nerfed: string;
+    let auth: string;
+    let username: string;
+    let email: string;
+    let password64: string;
+
+    url = npmrcparser.NormalizeRegistry( await getFeedRegistryUrl(defaultPackagingUri, RegistryType.npm, feed.feedId, feed.projectId, null, useSession));
+    nerfed = util.toNerfDart(url);
+
+    // Setting up auth info
+    const accessToken = getAccessToken();
+
+    // Azure DevOps does not support PATs+Bearer only JWTs+Bearer
+    email = 'VssEmail';
+    username = 'VssToken';
+    password64 = Buffer.from(accessToken).toString('base64');
+    tl.setSecret(password64);
+
+    auth = nerfed + ':username=' + username + lineEnd;
+    auth += nerfed + ':_password=' + password64 + lineEnd;
+    auth += nerfed + ':email=' + email + lineEnd;
+
+    return new NpmRegistry(url, auth, authOnly);
+}
+
+function getAccessToken(): string {
+    let accessToken: string;
+
+    let endpoint = tl.getInput('publishEndpoint', false);
+    if(endpoint) {
+        tl.debug("Found external endpoint, will use token for auth");
+        let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+        let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+        switch(endpointScheme)
+        {
+            case ("token"):
+                accessToken = endpointAuth.parameters["apitoken"];
+                break;
+            default:
+                tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                break;
+        }
+    }
+    if(!accessToken)
+    {
+        tl.debug('Defaulting to use the System Access Token.');
+        accessToken = getSystemAccessToken();
+    }
+    return accessToken;
 }

--- a/_generated/NpmV1_Node20/npmpublish.ts
+++ b/_generated/NpmV1_Node20/npmpublish.ts
@@ -5,7 +5,9 @@ import { INpmRegistry, NpmRegistry } from 'azure-pipelines-tasks-packaging-commo
 import { NpmToolRunner } from './npmtoolrunner';
 import * as util from 'azure-pipelines-tasks-packaging-common/util';
 import * as npmutil from 'azure-pipelines-tasks-packaging-common/npm/npmutil';
-import { PackagingLocation } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as npmrcparser from 'azure-pipelines-tasks-packaging-common/npm/npmrcparser';
+import { getSystemAccessToken, PackagingLocation, getFeedRegistryUrl, RegistryType } from 'azure-pipelines-tasks-packaging-common/locationUtilities';
+import * as os from 'os';
 
 export async function run(packagingLocation: PackagingLocation): Promise<void> {
     const workingDir = tl.getInput(NpmTaskInput.WorkingDir) || process.cwd();
@@ -33,10 +35,9 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
         case RegistryLocation.Feed:
             tl.debug(tl.loc('PublishFeed'));
             const feed = util.getProjectAndFeedIdFromInputParam(NpmTaskInput.PublishFeed);
-            npmRegistry = await NpmRegistry.FromFeedId(
+            npmRegistry = await getNpmRegistry(
                 packagingLocation.DefaultPackagingUri,
-                feed.feedId,
-                feed.projectId,
+                feed, 
                 false /* authOnly */,
                 true /* useSession */);
             break;
@@ -47,4 +48,58 @@ export async function getPublishRegistry(packagingLocation: PackagingLocation): 
             break;
     }
     return npmRegistry;
+}
+
+async function getNpmRegistry(defaultPackagingUri: string, feed: any, authOnly?: boolean, useSession?: boolean) {
+    const lineEnd = os.EOL;
+    let url: string;
+    let nerfed: string;
+    let auth: string;
+    let username: string;
+    let email: string;
+    let password64: string;
+
+    url = npmrcparser.NormalizeRegistry( await getFeedRegistryUrl(defaultPackagingUri, RegistryType.npm, feed.feedId, feed.projectId, null, useSession));
+    nerfed = util.toNerfDart(url);
+
+    // Setting up auth info
+    const accessToken = getAccessToken();
+
+    // Azure DevOps does not support PATs+Bearer only JWTs+Bearer
+    email = 'VssEmail';
+    username = 'VssToken';
+    password64 = Buffer.from(accessToken).toString('base64');
+    tl.setSecret(password64);
+
+    auth = nerfed + ':username=' + username + lineEnd;
+    auth += nerfed + ':_password=' + password64 + lineEnd;
+    auth += nerfed + ':email=' + email + lineEnd;
+
+    return new NpmRegistry(url, auth, authOnly);
+}
+
+function getAccessToken(): string {
+    let accessToken: string;
+
+    let endpoint = tl.getInput('publishEndpoint', false);
+    if(endpoint) {
+        tl.debug("Found external endpoint, will use token for auth");
+        let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+        let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+        switch(endpointScheme)
+        {
+            case ("token"):
+                accessToken = endpointAuth.parameters["apitoken"];
+                break;
+            default:
+                tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                break;
+        }
+    }
+    if(!accessToken)
+    {
+        tl.debug('Defaulting to use the System Access Token.');
+        accessToken = getSystemAccessToken();
+    }
+    return accessToken;
 }

--- a/_generated/NuGetCommandV2/nugetpublisher.ts
+++ b/_generated/NuGetCommandV2/nugetpublisher.ts
@@ -115,14 +115,13 @@ export async function run(nuGetPath: string): Promise<void> {
         let endpoint = tl.getInput('externalEndpoint', false);
 
         if(endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will try use token for auth");
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
             {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    tl.debug('let token:' + accessToken)
                     break;
                 default:
                     tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
@@ -130,7 +129,8 @@ export async function run(nuGetPath: string): Promise<void> {
             }
         }
         if(!accessToken && isInternalFeed === true)
-        {            
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
             const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
             if (JsonEndpointsString) {

--- a/_generated/NuGetCommandV2_Node20/nugetpublisher.ts
+++ b/_generated/NuGetCommandV2_Node20/nugetpublisher.ts
@@ -115,14 +115,13 @@ export async function run(nuGetPath: string): Promise<void> {
         let endpoint = tl.getInput('externalEndpoint', false);
 
         if(endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will try use token for auth");
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
             {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    tl.debug('let token:' + accessToken)
                     break;
                 default:
                     tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
@@ -130,7 +129,8 @@ export async function run(nuGetPath: string): Promise<void> {
             }
         }
         if(!accessToken && isInternalFeed === true)
-        {            
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
             const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
             if (JsonEndpointsString) {

--- a/_generated/UniversalPackagesV0/universalpublish.ts
+++ b/_generated/UniversalPackagesV0/universalpublish.ts
@@ -259,7 +259,31 @@ function authSetup(
         projectId = feedProject.projectId;
 
         // Setting up auth info
-        accessToken = pkgLocationUtils.getSystemAccessToken();
+        let endpoint = tl.getInput('externalEndpoints', false);
+        if(endpoint) {
+            tl.debug("Found external endpoint, will use token for auth");
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch(endpointScheme)
+            {
+                case ("token"):
+                    accessToken = endpointAuth.parameters["apitoken"];
+                    break;
+                default:
+                    tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                    break;
+            }
+        }
+        if(!accessToken)
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
+            accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
+        }
+        if(!accessToken)
+        {
+            tl.debug('Defaulting to use the System Access Token.');
+            accessToken = pkgLocationUtils.getSystemAccessToken();
+        }
     }
 
     else {

--- a/_generated/UniversalPackagesV0/universalpublish.ts
+++ b/_generated/UniversalPackagesV0/universalpublish.ts
@@ -261,7 +261,7 @@ function authSetup(
         // Setting up auth info
         let endpoint = tl.getInput('externalEndpoints', false);
         if(endpoint) {
-            tl.debug("Found external endpoint, will use token for auth");
+            tl.debug("Found external endpoint, will try to use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
@@ -276,7 +276,7 @@ function authSetup(
         }
         if(!accessToken)
         {           
-            tl.debug("Checking for auth from Cred Provider."); 
+            tl.debug("Checking for auth in environment variables."); 
             accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
         }
         if(!accessToken)

--- a/_generated/UniversalPackagesV0_Node20/universalpublish.ts
+++ b/_generated/UniversalPackagesV0_Node20/universalpublish.ts
@@ -259,7 +259,31 @@ function authSetup(
         projectId = feedProject.projectId;
 
         // Setting up auth info
-        accessToken = pkgLocationUtils.getSystemAccessToken();
+        let endpoint = tl.getInput('externalEndpoints', false);
+        if(endpoint) {
+            tl.debug("Found external endpoint, will use token for auth");
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch(endpointScheme)
+            {
+                case ("token"):
+                    accessToken = endpointAuth.parameters["apitoken"];
+                    break;
+                default:
+                    tl.warning("Invalid authentication type for internal feed. Use token based authentication.");
+                    break;
+            }
+        }
+        if(!accessToken)
+        {           
+            tl.debug("Checking for auth from Cred Provider."); 
+            accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
+        }
+        if(!accessToken)
+        {
+            tl.debug('Defaulting to use the System Access Token.');
+            accessToken = pkgLocationUtils.getSystemAccessToken();
+        }
     }
 
     else {

--- a/_generated/UniversalPackagesV0_Node20/universalpublish.ts
+++ b/_generated/UniversalPackagesV0_Node20/universalpublish.ts
@@ -261,7 +261,7 @@ function authSetup(
         // Setting up auth info
         let endpoint = tl.getInput('externalEndpoints', false);
         if(endpoint) {
-            tl.debug("Found external endpoint, will use token for auth");
+            tl.debug("Found external endpoint, will try to use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch(endpointScheme)
@@ -276,7 +276,7 @@ function authSetup(
         }
         if(!accessToken)
         {           
-            tl.debug("Checking for auth from Cred Provider."); 
+            tl.debug("Checking for auth in environment variables."); 
             accessToken = process.env["UNIVERSAL_PUBLISH_PAT"];
         }
         if(!accessToken)


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2, NpmV1, NuGetCommandV2 UniversalPackagesV0

**Description**: This PR targets the publish scenario for the above tasks. These changes will provide a new auth method when publishing to internal feeds. 

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N/A

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
